### PR TITLE
Include additional variables to specify vm's disk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,17 @@ terraform apply
 | control_plane_count              | Number of control plane VMs to create                        | string | 3 |
 | control_plane_memory             | Memory, in MB, to allocate to control plane VMs              | string | 16384 |
 | control_plane_num_cpus           | Number of CPUs to allocate for control plane VMs             | string | 4 |
+| control_plane_disk_size          | Disk Size, in GB, to allocate for control plane VMs          | number | 120 |
 | compute_ip_addresses             | List of IP addresses for your compute nodes                  | list   | - |
 | compute_count                    | Number of compute VMs to create                              | string | 3|
 | compute_memory                   | Memory, in MB, to allocate to compute VMs                    | string | 8192 |
 | compute_num_cpus                 | Number of CPUs to allocate for compute VMs                   | string | 3 |
+| compute_disk_size                | Disk Size, in GB, to allocate for compute VMs                | number | 60 |
 | storage_ip_addresses             | List of IP addresses for your storage nodes                   | list | `Empty` |
 | storage_count                    | Number of storage VMs to create                               | string | 0 |
 | storage_memory                   | Memory, in MB to allocate to storage VMs                     | string | 65536 |
 | storage_num_cpus                 | Number of CPUs to allocate for storage VMs                   | string | 16 |
+| storage_disk_size                | Disk Size, in GB, to allocate for storage VMs                | number | 120 |
 | openshift_pull_secret            | Path to your OpenShift [pull secret](https://cloud.redhat.com/openshift/install/vsphere/user-provisioned) | string | -                |
 | openshift_cluster_cidr           | CIDR for pods in the OpenShift SDN                           | string | 10.128.0.0/14 |
 | openshift_service_cidr           | CIDR for services in the OpenShift SDN                       | string | 172.30.0.0/16 |

--- a/ignition/main.tf
+++ b/ignition/main.tf
@@ -14,11 +14,11 @@ controlPlane:
   platform:
     vsphere:
       coresPerSocket: 1
-      cpus: ${var.master_cpu}
-      memoryMB: ${var.master_memory}
+      cpus: ${var.control_plane_num_cpus}
+      memoryMB: ${var.control_plane_memory}
       osDisk:
-        diskSizeGB: ${var.master_disk_size}
-  replicas: 3
+        diskSizeGB: ${var.control_plane_disk_size}
+  replicas: ${var.control_plane_count}
 metadata:
   name: ${var.cluster_id}
 networking:

--- a/ignition/variables.tf
+++ b/ignition/variables.tf
@@ -22,20 +22,40 @@ variable "machine_cidr" {
   type = string
 }
 
-variable "master_cpu" {
+variable "control_plane_count" {
   type    = string
-  default = 8
+  default = "3"
 }
 
-variable "master_disk_size" {
+variable "control_plane_memory" {
   type    = string
+  default = "16384"
+}
+
+variable "control_plane_num_cpus" {
+  type    = string
+  default = "4"
+}
+
+variable "control_plane_disk_size" {
+  type    = number 
   default = 120
 }
 
-variable "master_memory" {
-  type    = string
-  default = 32768
-}
+//variable "master_cpu" {
+//  type    = string
+//  default = 8
+//}
+
+//variable "master_disk_size" {
+//  type    = string
+//  default = 120
+//}
+
+//variable "master_memory" {
+//  type    = string
+//  default = 32768
+//}
 
 variable "pull_secret" {
   type = string

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,7 @@ module "bootstrap" {
 
   num_cpus      = 2
   memory        = 8192
+  disk_size     = 60
   dns_addresses = var.vm_dns_addresses
   vm_gateway    = var.vm_gateway == null ? cidrhost(var.machine_cidr, 1) : var.vm_gateway
 }
@@ -166,6 +167,7 @@ module "control_plane_vm" {
 
   num_cpus      = var.control_plane_num_cpus
   memory        = var.control_plane_memory
+  disk_size     = var.control_plane_disk_size
   dns_addresses = var.vm_dns_addresses
   vm_gateway    = var.vm_gateway == null ? cidrhost(var.machine_cidr, 1) : var.vm_gateway
 }
@@ -194,6 +196,7 @@ module "compute_vm" {
 
   num_cpus      = var.compute_num_cpus
   memory        = var.compute_memory
+  disk_size     = var.compute_disk_size
   dns_addresses = var.vm_dns_addresses
   vm_gateway    = var.vm_gateway == null ? cidrhost(var.machine_cidr, 1) : var.vm_gateway
 }
@@ -222,6 +225,7 @@ module "storage_vm" {
 
   num_cpus      = var.storage_num_cpus
   memory        = var.storage_memory
+  disk_size     = var.storage_disk_size
   dns_addresses = var.vm_dns_addresses
   vm_gateway    = var.vm_gateway == null ? cidrhost(var.machine_cidr, 1) : var.vm_gateway
 }

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,11 @@ variable "control_plane_num_cpus" {
   default = "4"
 }
 
+variable "control_plane_disk_size" {
+  type    = number 
+  default = 60
+}
+
 //////////
 // compute machine variables
 //////////
@@ -129,6 +134,11 @@ variable "compute_num_cpus" {
   default = "4"
 }
 
+variable "compute_disk_size" {
+  type    = number
+  default = 60  
+}
+
 //////////
 // storage machine variables
 //////////
@@ -151,6 +161,11 @@ variable "storage_memory" {
 variable "storage_num_cpus" {
   type    = string
   default = "16"
+}
+
+variable "storage_disk_size" {
+  type    = number
+  default = 120
 }
 
 variable "openshift_api_virtualip" {

--- a/vm/main.tf
+++ b/vm/main.tf
@@ -19,15 +19,6 @@ resource "vsphere_virtual_machine" "vm" {
   folder           = var.folder_id
   enable_disk_uuid = "true"
 
-  wait_for_guest_net_timeout  = "0"
-  wait_for_guest_net_routable = "false"
-
-  nested_hv_enabled = var.nested_hv_enabled
-
-  network_interface {
-    network_id = var.network_id
-  }
-
   dynamic "disk" {
     for_each = local.disk_sizes
     content {
@@ -36,6 +27,15 @@ resource "vsphere_virtual_machine" "vm" {
       thin_provisioned = var.disk_thin_provisioned
       unit_number      = disk.key
     }
+  }
+
+  wait_for_guest_net_timeout  = "0"
+  wait_for_guest_net_routable = "false"
+
+  nested_hv_enabled = var.nested_hv_enabled
+
+  network_interface {
+    network_id = var.network_id
   }
 
   clone {


### PR DESCRIPTION
The current Implementation of the terraform deployment uses a fixed disk size of 60Gb for each VM within the Cluster. I've added additional variables to allow different types of VM's within the cluster e.g. control plane, compute, storage nodes and be set with different disk sizes.